### PR TITLE
Feature/namespace scope

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,6 +74,15 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        env:
+        - name: CLIENT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: stats.podIP
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,15 +74,6 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
-        env:
-        - name: CLIENT_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: stats.podIP
-        - name: WATCH_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/internal/controller/glideinmanagerpilotset_controller.go
+++ b/internal/controller/glideinmanagerpilotset_controller.go
@@ -41,13 +41,13 @@ type GlideinManagerPilotSetReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=gmos.chtc.wisc.edu,resources=glideinmanagerpilotsets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=gmos.chtc.wisc.edu,resources=glideinmanagerpilotsets/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=gmos.chtc.wisc.edu,resources=glideinmanagerpilotsets/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
-//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=gmos.chtc.wisc.edu,namespace=memcached-operator-system,resources=glideinmanagerpilotsets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=gmos.chtc.wisc.edu,namespace=memcached-operator-system,resources=glideinmanagerpilotsets/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=gmos.chtc.wisc.edu,namespace=memcached-operator-system,resources=glideinmanagerpilotsets/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,namespace=memcached-operator-system,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=apps,namespace=memcached-operator-system,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,namespace=memcached-operator-system,resources=pods,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,namespace=memcached-operator-system,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/kustomize/base/operator-role/kustomization.yaml
+++ b/kustomize/base/operator-role/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - role_binding.yaml
+  - role.yaml

--- a/kustomize/base/operator-role/role.yaml
+++ b/kustomize/base/operator-role/role.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: manager-role
-  namespace: memcached-operator-system
 rules:
 - apiGroups:
   - apps

--- a/kustomize/base/operator-role/role_binding.yaml
+++ b/kustomize/base/operator-role/role_binding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system
+  namespace: gmos-k8s-operator-system

--- a/kustomize/dev/kustomization.yaml
+++ b/kustomize/dev/kustomization.yaml
@@ -2,6 +2,7 @@ namespace: dev
 
 bases:
   - ../base/gmos
+  - ../base/operator-role
 
 resources:
   - namespace.yaml

--- a/kustomize/operator/controller-manager-env.yaml
+++ b/kustomize/operator/controller-manager-env.yaml
@@ -12,3 +12,5 @@ spec:
         env:
         - name: CLIENT_NAME
           value: gmos-k8s-operator-controller-webservice.gmos-k8s-operator-system.svc.cluster.local
+        - name: WATCH_NAMESPACE
+          value: dev,prod

--- a/kustomize/prod/kustomization.yaml
+++ b/kustomize/prod/kustomization.yaml
@@ -1,5 +1,8 @@
 namespace: prod
 
+bases:
+  - ../base/operator-role
+
 resources:
   - namespace.yaml
   - pilot-set.yaml


### PR DESCRIPTION
- Change the operator from the default cluster scope to namespace scope, as per https://sdk.operatorframework.io/docs/building-operators/golang/operator-scope/
  - Makes the operator one-to-many with a comma-separated list of namespaces, rather than one-to-many with every namespace in the cluster
- Update the sample kustomize directory to include namespace roles for the operator in the dev and prod namespaces